### PR TITLE
Allocate a new AIDs for RFS module

### DIFF
--- a/include/private/android_filesystem_config.h
+++ b/include/private/android_filesystem_config.h
@@ -102,6 +102,8 @@
 #define AID_QCOM_DIAG     3009  /* can read/write /dev/diag */
 #define AID_IMS           3010 /* can read/write /dev/socket/imsrtp */
 #define AID_SENSORS       3011 /* access to /dev/socket/sensor_ctl_socket & QCCI/QCSI */
+#define AID_RFS           3012  /* Remote Filesystem for peripheral processors */
+#define AID_RFS_SHARED    3013  /* Shared files for Remote Filesystem for peripheral processors  */
 #endif
 
 #define AID_EVERYBODY     9997  /* shared between all apps in the same profile */
@@ -192,6 +194,8 @@ static const struct android_id_info android_ids[] = {
     { "qcom_diag", AID_QCOM_DIAG, },
 #if !defined(QCOM_LEGACY_UIDS)
     { "sensors",       AID_SENSORS, },
+    { "rfs",           AID_RFS, },
+    { "rfs_shared",    AID_RFS_SHARED, },
 #endif
     { "everybody",     AID_EVERYBODY, },
     { "misc",          AID_MISC, },


### PR DESCRIPTION
Allocate new AIDs to allow the RFS module
to run as after dropping privelages from
ROOT and to enforce strict permissions on
shared and private RFS files.

Change-Id: Ic4febd565df9f232f6c7571355ec10d8fd2e21bd