### PR TITLE
System/core: Use memmove

### DIFF
--- a/libutils/String8.cpp
+++ b/libutils/String8.cpp
@@ -424,7 +424,7 @@ bool String8::removeAll(const char* other) {
             next = len;
         }
 
-        memcpy(buf + tail, buf + index + skip, next - index - skip);
+        memmove(buf + tail, buf + index + skip, next - index - skip);
         tail += next - index - skip;
         index = next;
     }


### PR DESCRIPTION
Should use memmove when you expect overlap.

Change-Id: I268a173db40a4be54232958e37aa8a03c2a885ee